### PR TITLE
Update to work with jobqueue 0.5.0

### DIFF
--- a/jobqueue_features/clusters.py
+++ b/jobqueue_features/clusters.py
@@ -130,8 +130,8 @@ class CustomClusterMixin(object):
     pure = None  # type: bool
 
     def update_init_kwargs(self, **kwargs):  # type: (Dict[...]) -> Dict[...]
-        # self.scheduler_name is set by the JobQueueCluster class, make sure it exists
-        if not hasattr(self, "scheduler_name"):
+        # self.submit_command is set by the JobQueueCluster class, make sure it exists
+        if self.submit_command is None:
             raise NotImplementedError(
                 "For inheritance to work as intended you need to create new "
                 "CustomCluster class that inherits from the base CustomCluster class "
@@ -497,6 +497,7 @@ class CustomSLURMCluster(CustomClusterMixin, SLURMCluster):
      adds client attribute to SLURMCluster class."""
 
     def __init__(self, **kwargs):
+        self.scheduler_name = "slurm"
         kwargs = self.update_init_kwargs(**kwargs)
         # Do custom initialisation here
         if self.mpi_mode:

--- a/jobqueue_features/clusters_controller.py
+++ b/jobqueue_features/clusters_controller.py
@@ -45,6 +45,8 @@ class ClusterController(object):
         kwargs = {}
         if self.default_cluster is not LocalCluster:
             kwargs["name"] = name
+        else:
+            kwargs["processes"] = False
         return self.default_cluster(**kwargs)
 
     def _make_client(self, id_):

--- a/jobqueue_features/tests/test_cluster.py
+++ b/jobqueue_features/tests/test_cluster.py
@@ -55,7 +55,7 @@ class TestClusters(TestCase):
         self.assertIn(MPI_DASK_WRAPPER_MODULE, cluster._command_template)
         self.assertEqual(cluster.worker_cores, 1)
         self.assertEqual(cluster.worker_processes, 1)
-        self.assertEqual(cluster.worker_threads, 1)
+        self.assertEqual(cluster.worker_process_threads, 1)
         self.assertIsInstance(cluster.client, Client)
         with self.assertRaises(ValueError):
             get_cluster(
@@ -77,7 +77,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -n 130", cluster.job_script())
         self.assertEqual(cluster.worker_cores, 1)
         self.assertEqual(cluster.worker_processes, 1)
-        self.assertEqual(cluster.worker_threads, 1)
+        self.assertEqual(cluster.worker_process_threads, 1)
         with self.assertRaises(ValueError):
             get_cluster(queue_type="knl", mpi_mode=True, **self.kwargs)
         with self.assertRaises(ValueError):
@@ -108,7 +108,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
         self.assertEqual(cluster.worker_cores, 1)
         self.assertEqual(cluster.worker_processes, 1)
-        self.assertEqual(cluster.worker_threads, 1)
+        self.assertEqual(cluster.worker_process_threads, 1)
         self.assertIn("#SBATCH -n 8", cluster.job_script())
         self.assertIn(
             "export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}", cluster.job_script()
@@ -171,7 +171,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
         self.assertEqual(cluster.worker_cores, 1)
         self.assertEqual(cluster.worker_processes, 1)
-        self.assertEqual(cluster.worker_threads, 1)
+        self.assertEqual(cluster.worker_process_threads, 1)
         self.assertIn("#SBATCH -n 24", cluster.job_script())
         self.assertIn(
             "export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}", cluster.job_script()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-dask>=1.2.0
-distributed>=1.27
-dask_jobqueue>=0.4.1
+dask>=1.2.2
+distributed>=1.28
+dask_jobqueue>=0.5.0
 typing
 pytest-cov
 mpi4py


### PR DESCRIPTION
The base class no longer contains `self.scheduler_name` so we have to insert this ourselves for an easy fix.