### PR TITLE
Allow to pass only clusters in decorators inits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ venv.bak/
 
 # dask
 dask-worker-space/
+
+.idea/

--- a/jobqueue_features/clusters.py
+++ b/jobqueue_features/clusters.py
@@ -502,7 +502,7 @@ class CustomSLURMCluster(CustomClusterMixin, SLURMCluster):
     def __init__(self, **kwargs):
         self.scheduler_name = "slurm"
         kwargs = self.update_init_kwargs(**kwargs)
-        self._validate_name(kwargs['name'])
+        self._validate_name(kwargs["name"])
         # Do custom initialisation here
         if self.mpi_mode:
             # Most obvious customisation is for when we use mpi_mode, relevant variables
@@ -543,6 +543,7 @@ class CustomSLURMCluster(CustomClusterMixin, SLURMCluster):
 
     def _validate_name(self, name):
         from .clusters_controller import clusters_controller_singleton
+
         try:
             clusters_controller_singleton.get_cluster(id_=name)
         except:
@@ -552,6 +553,7 @@ class CustomSLURMCluster(CustomClusterMixin, SLURMCluster):
 
     def _add_to_cluster_controller(self):
         from .clusters_controller import clusters_controller_singleton
+
         clusters_controller_singleton.add_cluster(id_=self.name, cluster=self)
 
     def _update_script_nodes(self, **kwargs):  # type: () -> None

--- a/jobqueue_features/clusters.py
+++ b/jobqueue_features/clusters.py
@@ -7,6 +7,7 @@ from typing import TypeVar, Dict  # noqa
 
 from .cli.mpi_dask_worker import MPI_DASK_WRAPPER_MODULE
 from .mpi_wrapper import mpi_wrap
+from .custom_exceptions import ClusterException
 
 import logging
 
@@ -501,6 +502,7 @@ class CustomSLURMCluster(CustomClusterMixin, SLURMCluster):
     def __init__(self, **kwargs):
         self.scheduler_name = "slurm"
         kwargs = self.update_init_kwargs(**kwargs)
+        self._validate_name(kwargs['name'])
         # Do custom initialisation here
         if self.mpi_mode:
             # Most obvious customisation is for when we use mpi_mode, relevant variables
@@ -537,6 +539,20 @@ class CustomSLURMCluster(CustomClusterMixin, SLURMCluster):
             for warning in self.warnings:
                 logger.debug(warning)
             logger.debug("\n")
+        self._add_to_cluster_controller()
+
+    def _validate_name(self, name):
+        from .clusters_controller import clusters_controller_singleton
+        try:
+            clusters_controller_singleton.get_cluster(id_=name)
+        except:
+            pass
+        else:
+            raise ClusterException('Cluster with name "{}" already exists'.format(name))
+
+    def _add_to_cluster_controller(self):
+        from .clusters_controller import clusters_controller_singleton
+        clusters_controller_singleton.add_cluster(id_=self.name, cluster=self)
 
     def _update_script_nodes(self, **kwargs):  # type: () -> None
         # If we're not in mpi_mode no need to do anything

--- a/jobqueue_features/clusters_controller.py
+++ b/jobqueue_features/clusters_controller.py
@@ -6,6 +6,8 @@ from dask.distributed import Client, LocalCluster
 from .clusters import ClusterType  # noqa
 from .custom_exceptions import ClusterException
 
+_DEFAULT = "default"
+
 
 class ClusterController(object):
     """Controller keeps collection of clusters and clients so it can
@@ -15,27 +17,37 @@ class ClusterController(object):
 
     def __init__(self):
         # type: () -> None
-        self._clusters = {"default": None}  # type: Dict[str, ClusterType]
-        self._clients = {"default": None}  # type: Dict[str, Client]
+        self._clusters = {_DEFAULT: None}  # type: Dict[str, ClusterType]
+        self._clients = {_DEFAULT: None}  # type: Dict[str, Client]
         atexit.register(self._close)
 
     def get_cluster(self, id_=None):
         # type: (str) -> Tuple[ClusterType, Client]
-        cluster = self._clusters.get(id_ or "default")
+        cluster = self._clusters.get(id_ or _DEFAULT)
         if cluster is None:
             raise ClusterException('No cluster "{}" set!'.format(id_))
-        client = self._clients.get(id_ or "default")
+        client = self._clients.get(id_ or _DEFAULT)
         if client is None:
             raise ClusterException('No client for cluster "{}" set!'.format(id_))
         return cluster, client
 
     def add_cluster(self, id_=None, cluster=None):
         # type: (str, ClusterType) -> Tuple[ClusterType, Client]
-        return self._make_cluster(id_=id_ or "default", cluster=cluster)
+        if hasattr(cluster, "name"):
+            if id_ is None:
+                id_ = cluster.name
+            else:
+                assert id_ == cluster.name
+        return self._make_cluster(id_=id_ or _DEFAULT, cluster=cluster)
+
+    def delete_cluster(self, id_):
+        # type: (str) -> None
+        self._close_client(id_=id_)
+        self._close_cluster(id_=id_)
 
     def _make_cluster(self, id_, cluster=None):
         # type: (str, ClusterType) -> Tuple[ClusterType, Client]
-        if id_ != "default" and id_ in self._clusters:
+        if id_ != _DEFAULT and id_ in self._clusters:
             raise ClusterException('Cluster "{}" already exists!'.format(id_))
         self._clusters[id_] = cluster or self._make_default_cluster(name=id_)
         self._make_client(id_=id_)
@@ -63,19 +75,29 @@ class ClusterController(object):
         self._close_clients()
         self._close_clusters()
 
+    def _close_cluster(self, id_):
+        # type: (str) -> None
+        cluster = self._clusters.pop(id_, None)
+        if cluster and type(cluster) is not LocalCluster:
+            cluster.close()
+
     def _close_clusters(self):
         # type: () -> None
-        for cluster in self._clusters.values():
-            if cluster and type(cluster) is not LocalCluster:
-                cluster.close()
-        self._clusters = {"default": None}
+        for id_ in list(self._clusters.keys()):
+            self._close_cluster(id_)
+        self._clusters = {_DEFAULT: None}
+
+    def _close_client(self, id_):
+        # type: (str) -> None
+        client = self._clients.get(id_)
+        if client:
+            client.close()
 
     def _close_clients(self):
         # type: () -> None
-        for client in self._clients.values():
-            if client:
-                client.close()
-        self._clients = {"default": None}
+        for id_ in list(self._clients.keys()):
+            self._close_client(id_)
+        self._clients = {_DEFAULT: None}
 
 
 clusters_controller_singleton = ClusterController()

--- a/jobqueue_features/decorators.py
+++ b/jobqueue_features/decorators.py
@@ -97,7 +97,9 @@ class on_cluster(object):
                     return cluster.name
             else:
                 if cluster_id is None:
-                    raise ClusterException('LocalCluster requires "cluster_id" argument.')
+                    raise ClusterException(
+                        'LocalCluster requires "cluster_id" argument.'
+                    )
                 return cluster_id
         return cluster_id
 
@@ -122,11 +124,15 @@ class task(object):
                 if not _id:
                     raise ClusterException("Cluster has no name attribute set.")
                 elif cluster_id and _id != cluster_id:
-                    raise ClusterException("Cluster 'name' and cluster_id are different.")
+                    raise ClusterException(
+                        "Cluster 'name' and cluster_id are different."
+                    )
                 else:
                     self.cluster_id = _id
             elif not cluster_id:
-                raise ClusterException("'cluster_id' argument is required for LocalCluster.")
+                raise ClusterException(
+                    "'cluster_id' argument is required for LocalCluster."
+                )
 
     def __call__(self, f):
         # type: (Callable) -> Callable

--- a/jobqueue_features/tests/test_cluster.py
+++ b/jobqueue_features/tests/test_cluster.py
@@ -4,6 +4,7 @@ from dask.distributed import Client
 from jobqueue_features.clusters import get_cluster, SLURM
 from jobqueue_features.mpi_wrapper import SRUN
 from jobqueue_features.cli.mpi_dask_worker import MPI_DASK_WRAPPER_MODULE
+from jobqueue_features.clusters_controller import clusters_controller_singleton as controller
 
 
 class TestClusters(TestCase):
@@ -23,6 +24,7 @@ class TestClusters(TestCase):
         self.assertIsInstance(cluster.client, Client)
         with self.assertRaises(ValueError):
             get_cluster(SLURM, cores=128, **self.kwargs)
+        controller.delete_cluster(cluster.name)
 
     def test_gpu_cluster(self):
         cluster = get_cluster(queue_type="gpus", **self.kwargs)
@@ -30,6 +32,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -p gpus", cluster.job_header)
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
         self.assertIsInstance(cluster.client, Client)
+        controller.delete_cluster(cluster.name)
 
     def test_knl_cluster(self):
         cluster = get_cluster(queue_type="knl", **self.kwargs)
@@ -37,6 +40,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -p booster", cluster.job_header)
         self.assertIn("#SBATCH --cpus-per-task=64", cluster.job_header)
         self.assertIsInstance(cluster.client, Client)
+        controller.delete_cluster(cluster.name)
 
     def test_nonexistent_queue_type(self):
         with self.assertRaises(ValueError) as context:
@@ -57,10 +61,12 @@ class TestClusters(TestCase):
         self.assertEqual(cluster.worker_processes, 1)
         self.assertEqual(cluster.worker_process_threads, 1)
         self.assertIsInstance(cluster.client, Client)
+        controller.delete_cluster(cluster.name)
         with self.assertRaises(ValueError):
-            get_cluster(
+            cluster = get_cluster(
                 queue_type="knl", mpi_mode=True, nodes=64, cores=64, **self.kwargs
             )
+            controller.delete_cluster(cluster.name)
 
     def test_fork_mpi_job_cluster(self):
         # First do a simple mpi job
@@ -68,6 +74,7 @@ class TestClusters(TestCase):
         kwargs.update({"fork_mpi": True})
         cluster = get_cluster(queue_type="knl", mpi_mode=True, cores=64, **kwargs)
         self.assertNotIn(MPI_DASK_WRAPPER_MODULE, cluster._command_template)
+        controller.delete_cluster(cluster.name)
 
     def test_mpi_multi_node_job_cluster(self):
         # First do a simple mpi job
@@ -96,6 +103,7 @@ class TestClusters(TestCase):
                 mpi_mode=True,
                 **self.kwargs
             )
+        controller.delete_cluster(cluster.name)
 
     def test_mpi_complex_job_cluster(self):
         # Now a few more variables
@@ -123,13 +131,14 @@ class TestClusters(TestCase):
             # 24/2 = 12). For an MPI job we expect the core count (which is the total
             # number of cores to be used) to be divisible by cpus_per_tasks but that is
             # not true in this case resulting in a ValueError
-            cluster = get_cluster(
+            get_cluster(
                 queue_type="gpus",
                 mpi_mode=True,
                 cores=2,
                 ntasks_per_node=2,
                 **self.kwargs
             )
+        controller.delete_cluster("dask-worker-gpus")
         # If you really want this you ask for it explicitly
         cluster = get_cluster(
             queue_type="gpus",
@@ -144,6 +153,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -n 2", cluster.job_header)
         self.assertNotIn("#SBATCH --nodes", cluster.job_header)
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
+        controller.delete_cluster(cluster.name)
         # For memory pinning stuff that may be done by the scheduler, it is probably
         # better to ask for it like this (even if you don't intend to use OpenMP)
         cluster = get_cluster(
@@ -154,6 +164,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -n 2", cluster.job_header)
         self.assertIn("#SBATCH --nodes=1", cluster.job_header)
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
+        controller.delete_cluster(cluster.name)
 
     def test_mpi_explicit_job_cluster(self):
         # Now a few more variables
@@ -178,6 +189,7 @@ class TestClusters(TestCase):
         )
         self.assertIn("export OMP_PROC_BIND=spread", cluster.job_script())
         self.assertIn("export OMP_PLACES=threads", cluster.job_script())
+        controller.delete_cluster(cluster.name)
 
     def test_scheduler_fail_job_cluster(self):
         with self.assertRaises(NotImplementedError):

--- a/jobqueue_features/tests/test_cluster.py
+++ b/jobqueue_features/tests/test_cluster.py
@@ -4,6 +4,7 @@ from dask.distributed import Client
 from jobqueue_features.clusters import get_cluster, SLURM
 from jobqueue_features.mpi_wrapper import SRUN
 from jobqueue_features.cli.mpi_dask_worker import MPI_DASK_WRAPPER_MODULE
+from jobqueue_features.clusters_controller import clusters_controller_singleton as controller
 
 
 class TestClusters(TestCase):
@@ -23,6 +24,7 @@ class TestClusters(TestCase):
         self.assertIsInstance(cluster.client, Client)
         with self.assertRaises(ValueError):
             get_cluster(SLURM, cores=128, **self.kwargs)
+        controller.delete_cluster(cluster.name)
 
     def test_gpu_cluster(self):
         cluster = get_cluster(queue_type="gpus", **self.kwargs)
@@ -30,6 +32,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -p gpus", cluster.job_header)
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
         self.assertIsInstance(cluster.client, Client)
+        controller.delete_cluster(cluster.name)
 
     def test_knl_cluster(self):
         cluster = get_cluster(queue_type="knl", **self.kwargs)
@@ -37,6 +40,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -p booster", cluster.job_header)
         self.assertIn("#SBATCH --cpus-per-task=64", cluster.job_header)
         self.assertIsInstance(cluster.client, Client)
+        controller.delete_cluster(cluster.name)
 
     def test_nonexistent_queue_type(self):
         with self.assertRaises(ValueError) as context:
@@ -57,10 +61,12 @@ class TestClusters(TestCase):
         self.assertEqual(cluster.worker_processes, 1)
         self.assertEqual(cluster.worker_process_threads, 1)
         self.assertIsInstance(cluster.client, Client)
+        controller.delete_cluster(cluster.name)
         with self.assertRaises(ValueError):
-            get_cluster(
+            cluster = get_cluster(
                 queue_type="knl", mpi_mode=True, nodes=64, cores=64, **self.kwargs
             )
+            controller.delete_cluster(cluster.name)
 
     def test_fork_mpi_job_cluster(self):
         # First do a simple mpi job
@@ -68,6 +74,7 @@ class TestClusters(TestCase):
         kwargs.update({"fork_mpi": True})
         cluster = get_cluster(queue_type="knl", mpi_mode=True, cores=64, **kwargs)
         self.assertNotIn(MPI_DASK_WRAPPER_MODULE, cluster._command_template)
+        controller.delete_cluster(cluster.name)
 
     def test_mpi_multi_node_job_cluster(self):
         # First do a simple mpi job
@@ -96,6 +103,7 @@ class TestClusters(TestCase):
                 mpi_mode=True,
                 **self.kwargs
             )
+        controller.delete_cluster(cluster.name)
 
     def test_mpi_complex_job_cluster(self):
         # Now a few more variables
@@ -115,15 +123,16 @@ class TestClusters(TestCase):
         )
         self.assertIn("export OMP_PROC_BIND=spread", cluster.job_script())
         self.assertIn("export OMP_PLACES=threads", cluster.job_script())
+        controller.delete_cluster(cluster.name)
 
     def test_mpi_complex_job_cluster_fail(self):
         # Now a few more variables
-        with self.assertRaises(ValueError):
+        with self.assertRaises(ValueError) as ctx:
             # When we provide ntasks_per_node, cpus_per_tasks is derived (in this case
             # 24/2 = 12). For an MPI job we expect the core count (which is the total
             # number of cores to be used) to be divisible by cpus_per_tasks but that is
             # not true in this case resulting in a ValueError
-            cluster = get_cluster(
+            get_cluster(
                 queue_type="gpus",
                 mpi_mode=True,
                 cores=2,
@@ -144,6 +153,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -n 2", cluster.job_header)
         self.assertNotIn("#SBATCH --nodes", cluster.job_header)
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
+        controller.delete_cluster(cluster.name)
         # For memory pinning stuff that may be done by the scheduler, it is probably
         # better to ask for it like this (even if you don't intend to use OpenMP)
         cluster = get_cluster(
@@ -154,6 +164,7 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH -n 2", cluster.job_header)
         self.assertIn("#SBATCH --nodes=1", cluster.job_header)
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
+        controller.delete_cluster(cluster.name)
 
     def test_mpi_explicit_job_cluster(self):
         # Now a few more variables
@@ -178,6 +189,7 @@ class TestClusters(TestCase):
         )
         self.assertIn("export OMP_PROC_BIND=spread", cluster.job_script())
         self.assertIn("export OMP_PLACES=threads", cluster.job_script())
+        controller.delete_cluster(cluster.name)
 
     def test_scheduler_fail_job_cluster(self):
         with self.assertRaises(NotImplementedError):

--- a/jobqueue_features/tests/test_cluster.py
+++ b/jobqueue_features/tests/test_cluster.py
@@ -4,7 +4,9 @@ from dask.distributed import Client
 from jobqueue_features.clusters import get_cluster, SLURM
 from jobqueue_features.mpi_wrapper import SRUN
 from jobqueue_features.cli.mpi_dask_worker import MPI_DASK_WRAPPER_MODULE
-from jobqueue_features.clusters_controller import clusters_controller_singleton as controller
+from jobqueue_features.clusters_controller import (
+    clusters_controller_singleton as controller,
+)
 
 
 class TestClusters(TestCase):

--- a/jobqueue_features/tests/test_decorators.py
+++ b/jobqueue_features/tests/test_decorators.py
@@ -1,41 +1,316 @@
 from __future__ import absolute_import
+
 from unittest import TestCase
 from dask.distributed import Client, LocalCluster, Future
 
 from jobqueue_features import on_cluster, set_default_cluster, task, ClusterException
-from jobqueue_features.clusters_controller import clusters_controller_singleton
+from jobqueue_features.clusters import CustomSLURMCluster
+from jobqueue_features.clusters_controller import clusters_controller_singleton as controller
 
 
-class TestDecorators(TestCase):
+class TweakedCustomCluster(CustomSLURMCluster):
+    def __init__(self, **kwargs):
+        kwargs["interface"] = ""
+        super(TweakedCustomCluster, self).__init__(**kwargs)
+
+
+# monkey patch the CustomSLURMCluster so it can be initialized without providing
+# the "interface" attribute
+CustomSLURMCluster = TweakedCustomCluster
+
+
+class TestOnClusterDecorator(TestCase):
+    """
+    Test @on_cluster() decorator against several scenarios of providing clusters or clusters
+    IDs to the initializer of decorator for getting/adding clusters from cluster controller.
+
+    cluster=None,         cluster_id=None : default cluster
+    cluster=SLURMCluster, cluster_id=None : register cluster by its name
+    cluster=LocalCluster, cluster_id=None : error
+    cluster=None,         cluster_id=str  : when default cluster is LocalCLuster check for cluster with such id
+    cluster=None,         cluster_id=str  : when default cluster is SLURMCluster check for cluster with such id
+    cluster=SLURMCluster, cluster_id=str  : assert cluster.name == id
+    cluster=LocalCluster, cluster_id=str  : register cluster by given id
+    """
+    def tearDown(self):
+        controller._close()
+
+    def test_default_behavior(self):
+        self._test_default_behavior(cluster_type=CustomSLURMCluster)
+
+    def test_default_behavior_local(self):
+        self._test_default_behavior(cluster_type=LocalCluster)
+
+    def test_init_only_cluster(self):
+        original_cluster = CustomSLURMCluster()
+
+        @on_cluster(cluster=original_cluster)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(original_cluster.name)
+        self.assertEqual(original_cluster, cluster)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(cluster.name)
+
+        _id = "test1"
+        original_cluster = CustomSLURMCluster(name=_id)
+
+        @on_cluster(cluster=original_cluster)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(cluster.name)
+
+    def test_init_only_cluster_local(self):
+        original_cluster = LocalCluster()
+        with self.assertRaises(ClusterException) as ctx:
+            @on_cluster(cluster=original_cluster)
+            def f():
+                pass
+        self.assertEqual('LocalCluster requires "cluster_id" argument.',
+                         str(ctx.exception))
+
+        _id = "test1"
+
+        @on_cluster(cluster=original_cluster, cluster_id=_id)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(_id)
+
+    def test_init_only_id(self):
+        _id = "test1"
+        original_cluster = CustomSLURMCluster(name=_id)
+        with self.assertRaises(ClusterException) as ctx:
+            controller.add_cluster(cluster=original_cluster)
+        self.assertEqual('Cluster "{}" already exists!'.format(_id),
+                         str(ctx.exception))
+
+        @on_cluster(cluster_id=_id)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(id_=_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertEqual(cluster.name, _id)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(_id)
+
+    def test_init_only_id_local(self):
+        _id = "test1"
+        original_cluster = LocalCluster()
+        controller.add_cluster(id_=_id, cluster=original_cluster)
+
+        @on_cluster(cluster_id=_id)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(id_=_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(_id)
+
+    def test_init_both_cluster_and_id(self):
+        _id = "test1"
+        original_cluster = CustomSLURMCluster()
+
+        with self.assertRaises(AssertionError):
+            @on_cluster(cluster_id=_id, cluster=original_cluster)
+            def f():
+                pass
+        controller.delete_cluster(original_cluster.name)
+        original_cluster = CustomSLURMCluster()
+
+        @on_cluster(cluster_id=original_cluster.name, cluster=original_cluster)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(id_=original_cluster.name)
+        self.assertEqual(original_cluster, cluster)
+        self.assertEqual(cluster.name, original_cluster.name)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(original_cluster.name)
+
+        original_cluster = CustomSLURMCluster(name=_id)
+
+        @on_cluster(cluster_id=_id, cluster=original_cluster)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(id_=_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertEqual(cluster.name, _id)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(_id)
+
+    def _test_default_behavior(self, cluster_type):
+        set_default_cluster(cluster_type)
+
+        @on_cluster()
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster()
+        self.assertIsInstance(cluster, cluster_type)
+        self.assertIsInstance(client, Client)
+
+
+class TestTaskDecorator(TestCase):
+    def tearDown(self):
+        controller._close()
+
+    def test_default_behavior(self):
+        cluster_type = CustomSLURMCluster
+        set_default_cluster(cluster_type)
+        _value = 123
+
+        @on_cluster()
+        @task()
+        def f():
+            return _value
+
+        self._basic_tests(cluster_type)
+
+    def test_task_by_id_string(self):
+        _id = "test1"
+        cluster_type = CustomSLURMCluster
+        original_cluster = cluster_type(name=_id)
+
+        @on_cluster(cluster=original_cluster)
+        @task(cluster_id=_id)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=_id)
+        controller.delete_cluster(_id)
+
+    def test_task_by_cluster_name(self):
+        _id = "test1"
+        cluster_type = CustomSLURMCluster
+        original_cluster = cluster_type(name=_id)
+
+        @on_cluster(cluster=original_cluster)
+        @task(cluster_id=original_cluster.name)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=original_cluster.name)
+        controller.delete_cluster(original_cluster.name)
+
+    def test_task_by_cluster(self):
+        cluster_type = CustomSLURMCluster
+        original_cluster = cluster_type()
+
+        @on_cluster(cluster=original_cluster)
+        @task(cluster=original_cluster)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=original_cluster.name)
+        controller.delete_cluster(original_cluster.name)
+
+    def test_task_by_cluster_local(self):
+        _id = "test1"
+        cluster_type = LocalCluster
+        original_cluster = cluster_type()
+
+        with self.assertRaises(ClusterException) as ctx:
+            @on_cluster(cluster=original_cluster, cluster_id=_id)
+            @task(cluster=original_cluster)
+            def f():
+                pass
+        self.assertEqual("'cluster_id' argument is required for LocalCluster.",
+                         str(ctx.exception))
+
+        @on_cluster(cluster=original_cluster, cluster_id=_id)
+        @task(cluster=original_cluster, cluster_id=_id)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=_id)
+        controller.delete_cluster(_id)
+
+    def test_task_by_cluster_and_cluster_id(self):
+        _id = "test1"
+        cluster_type = CustomSLURMCluster
+        original_cluster = cluster_type(name=_id)
+
+        with self.assertRaises(ClusterException) as ctx:
+            @on_cluster(cluster=original_cluster)
+            @task(cluster=original_cluster, cluster_id="bad name")
+            def f():
+                pass
+        self.assertEqual("Cluster 'name' and cluster_id are different.",
+                         str(ctx.exception))
+
+        @on_cluster(cluster=original_cluster)
+        @task(cluster=original_cluster, cluster_id=_id)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=original_cluster.name)
+        controller.delete_cluster(original_cluster.name)
+
+    def test_task_by_cluster_and_cluster_id_local(self):
+        _id = "test1"
+        cluster_type = LocalCluster
+        original_cluster = cluster_type()
+
+        @on_cluster(cluster=original_cluster, cluster_id=_id)
+        @task(cluster=original_cluster, cluster_id="_id")
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=_id)
+        controller.delete_cluster(id_=_id)
+
+    def _basic_tests(self, cluster_type, id_=None):
+        cluster, client = controller.get_cluster(id_)
+        self.assertIsInstance(cluster, cluster_type)
+        self.assertIsInstance(client, Client)
+        self.assertEqual(controller.default_cluster.__class__, cluster_type.__class__)
+
+
+class TestTaskExecutionLocalCluster(TestCase):
     def setUp(self):
         self.cluster_type = LocalCluster
         set_default_cluster(self.cluster_type)
 
-        @on_cluster()
-        @task()
-        def example_function():
-            return "test"
-
-        self.function = example_function
-
     def tearDown(self):
-        clusters_controller_singleton._close()
+        controller._close()
 
-    def test_init(self):
-        cluster, client = clusters_controller_singleton.get_cluster()
+    def test_init_blank(self):
+        @on_cluster()
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster()
         self.assertIsInstance(cluster, self.cluster_type)
         self.assertIsInstance(client, Client)
 
     def test_call(self):
-        r = self.function()
+        @on_cluster()
+        @task()
+        def f():
+            return "test"
+        r = f()
         self.assertIsInstance(r, Future)
         self.assertEqual(r.result(), "test")
 
     def test_bad_task(self):
-        with self.assertRaises(ClusterException):
-
-            @task(cluster_id="bad_ID")
+        _id = "bad_ID"
+        with self.assertRaises(ClusterException) as ctx:
+            @task(cluster_id=_id)
             def bad_function():
                 return "test"
 
             bad_function()
+        self.assertEqual('No cluster "{}" set!'.format(_id),
+                         str(ctx.exception))

--- a/jobqueue_features/tests/test_decorators.py
+++ b/jobqueue_features/tests/test_decorators.py
@@ -1,41 +1,316 @@
 from __future__ import absolute_import
+
 from unittest import TestCase
 from dask.distributed import Client, LocalCluster, Future
 
 from jobqueue_features import on_cluster, set_default_cluster, task, ClusterException
-from jobqueue_features.clusters_controller import clusters_controller_singleton
+from jobqueue_features.clusters import CustomSLURMCluster
+from jobqueue_features.clusters_controller import clusters_controller_singleton as controller
 
 
-class TestDecorators(TestCase):
+class TweakedCustomCluster(CustomSLURMCluster):
+    def __init__(self, **kwargs):
+        kwargs["interface"] = ""
+        super(TweakedCustomCluster, self).__init__(**kwargs)
+
+
+# monkey patch the CustomSLURMCluster so it can be initialized without providing
+# the "interface" attribute
+CustomSLURMCluster = TweakedCustomCluster
+
+
+class TestOnClusterDecorator(TestCase):
+    """
+    Test @on_cluster() decorator against several scenarios of providing clusters or clusters
+    IDs to the initializer of decorator for getting/adding clusters from cluster controller.
+
+    cluster=None,         cluster_id=None : default cluster
+    cluster=SLURMCluster, cluster_id=None : register cluster by its name
+    cluster=LocalCluster, cluster_id=None : error
+    cluster=None,         cluster_id=str  : when default cluster is LocalCLuster check for cluster with such id
+    cluster=None,         cluster_id=str  : when default cluster is SLURMCluster check for cluster with such id
+    cluster=SLURMCluster, cluster_id=str  : assert cluster.name == id
+    cluster=LocalCluster, cluster_id=str  : register cluster by given id
+    """
+    def tearDown(self):
+        controller._close()
+
+    def test_default_behavior(self):
+        self._test_default_behavior(cluster_type=CustomSLURMCluster)
+
+    def test_default_behavior_local(self):
+        self._test_default_behavior(cluster_type=LocalCluster)
+
+    def test_init_only_cluster(self):
+        original_cluster = CustomSLURMCluster()
+
+        @on_cluster(cluster=original_cluster)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(original_cluster.name)
+        self.assertEqual(original_cluster, cluster)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(cluster.name)
+
+        _id = "test1"
+        original_cluster = CustomSLURMCluster(name=_id)
+
+        @on_cluster(cluster=original_cluster)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(cluster.name)
+
+    def test_init_only_cluster_local(self):
+        original_cluster = LocalCluster()
+        with self.assertRaises(ClusterException) as ctx:
+            @on_cluster(cluster=original_cluster)
+            def f():
+                pass
+        self.assertEqual('LocalCluster requires "cluster_id" argument.',
+                         ctx.exception.message)
+
+        _id = "test1"
+
+        @on_cluster(cluster=original_cluster, cluster_id=_id)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(_id)
+
+    def test_init_only_id(self):
+        _id = "test1"
+        original_cluster = CustomSLURMCluster(name=_id)
+        with self.assertRaises(ClusterException) as ctx:
+            controller.add_cluster(cluster=original_cluster)
+        self.assertEqual('Cluster "{}" already exists!'.format(_id),
+                         ctx.exception.message)
+
+        @on_cluster(cluster_id=_id)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(id_=_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertEqual(cluster.name, _id)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(_id)
+
+    def test_init_only_id_local(self):
+        _id = "test1"
+        original_cluster = LocalCluster()
+        controller.add_cluster(id_=_id, cluster=original_cluster)
+
+        @on_cluster(cluster_id=_id)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(id_=_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(_id)
+
+    def test_init_both_cluster_and_id(self):
+        _id = "test1"
+        original_cluster = CustomSLURMCluster()
+
+        with self.assertRaises(AssertionError):
+            @on_cluster(cluster_id=_id, cluster=original_cluster)
+            def f():
+                pass
+        controller.delete_cluster(original_cluster.name)
+        original_cluster = CustomSLURMCluster()
+
+        @on_cluster(cluster_id=original_cluster.name, cluster=original_cluster)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(id_=original_cluster.name)
+        self.assertEqual(original_cluster, cluster)
+        self.assertEqual(cluster.name, original_cluster.name)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(original_cluster.name)
+
+        original_cluster = CustomSLURMCluster(name=_id)
+
+        @on_cluster(cluster_id=_id, cluster=original_cluster)
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster(id_=_id)
+        self.assertEqual(original_cluster, cluster)
+        self.assertEqual(cluster.name, _id)
+        self.assertIsInstance(client, Client)
+        controller.delete_cluster(_id)
+
+    def _test_default_behavior(self, cluster_type):
+        set_default_cluster(cluster_type)
+
+        @on_cluster()
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster()
+        self.assertIsInstance(cluster, cluster_type)
+        self.assertIsInstance(client, Client)
+
+
+class TestTaskDecorator(TestCase):
+    def tearDown(self):
+        controller._close()
+
+    def test_default_behavior(self):
+        cluster_type = CustomSLURMCluster
+        set_default_cluster(cluster_type)
+        _value = 123
+
+        @on_cluster()
+        @task()
+        def f():
+            return _value
+
+        self._basic_tests(cluster_type)
+
+    def test_task_by_id_string(self):
+        _id = "test1"
+        cluster_type = CustomSLURMCluster
+        original_cluster = cluster_type(name=_id)
+
+        @on_cluster(cluster=original_cluster)
+        @task(cluster_id=_id)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=_id)
+        controller.delete_cluster(_id)
+
+    def test_task_by_cluster_name(self):
+        _id = "test1"
+        cluster_type = CustomSLURMCluster
+        original_cluster = cluster_type(name=_id)
+
+        @on_cluster(cluster=original_cluster)
+        @task(cluster_id=original_cluster.name)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=original_cluster.name)
+        controller.delete_cluster(original_cluster.name)
+
+    def test_task_by_cluster(self):
+        cluster_type = CustomSLURMCluster
+        original_cluster = cluster_type()
+
+        @on_cluster(cluster=original_cluster)
+        @task(cluster=original_cluster)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=original_cluster.name)
+        controller.delete_cluster(original_cluster.name)
+
+    def test_task_by_cluster_local(self):
+        _id = "test1"
+        cluster_type = LocalCluster
+        original_cluster = cluster_type()
+
+        with self.assertRaises(ClusterException) as ctx:
+            @on_cluster(cluster=original_cluster, cluster_id=_id)
+            @task(cluster=original_cluster)
+            def f():
+                pass
+        self.assertEqual("'cluster_id' argument is required for LocalCluster.",
+                         ctx.exception.message)
+
+        @on_cluster(cluster=original_cluster, cluster_id=_id)
+        @task(cluster=original_cluster, cluster_id=_id)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=_id)
+        controller.delete_cluster(_id)
+
+    def test_task_by_cluster_and_cluster_id(self):
+        _id = "test1"
+        cluster_type = CustomSLURMCluster
+        original_cluster = cluster_type(name=_id)
+
+        with self.assertRaises(ClusterException) as ctx:
+            @on_cluster(cluster=original_cluster)
+            @task(cluster=original_cluster, cluster_id="bad name")
+            def f():
+                pass
+        self.assertEqual("Cluster 'name' and cluster_id are different.",
+                         ctx.exception.message)
+
+        @on_cluster(cluster=original_cluster)
+        @task(cluster=original_cluster, cluster_id=_id)
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=original_cluster.name)
+        controller.delete_cluster(original_cluster.name)
+
+    def test_task_by_cluster_and_cluster_id_local(self):
+        _id = "test1"
+        cluster_type = LocalCluster
+        original_cluster = cluster_type()
+
+        @on_cluster(cluster=original_cluster, cluster_id=_id)
+        @task(cluster=original_cluster, cluster_id="_id")
+        def f():
+            pass
+
+        self._basic_tests(cluster_type=cluster_type, id_=_id)
+        controller.delete_cluster(id_=_id)
+
+    def _basic_tests(self, cluster_type, id_=None):
+        cluster, client = controller.get_cluster(id_)
+        self.assertIsInstance(cluster, cluster_type)
+        self.assertIsInstance(client, Client)
+        self.assertEqual(controller.default_cluster.__class__, cluster_type.__class__)
+
+
+class TestTaskExecutionLocalCluster(TestCase):
     def setUp(self):
         self.cluster_type = LocalCluster
         set_default_cluster(self.cluster_type)
 
-        @on_cluster()
-        @task()
-        def example_function():
-            return "test"
-
-        self.function = example_function
-
     def tearDown(self):
-        clusters_controller_singleton._close()
+        controller._close()
 
-    def test_init(self):
-        cluster, client = clusters_controller_singleton.get_cluster()
+    def test_init_blank(self):
+        @on_cluster()
+        def f():
+            pass
+
+        cluster, client = controller.get_cluster()
         self.assertIsInstance(cluster, self.cluster_type)
         self.assertIsInstance(client, Client)
 
     def test_call(self):
-        r = self.function()
+        @on_cluster()
+        @task()
+        def f():
+            return "test"
+        r = f()
         self.assertIsInstance(r, Future)
         self.assertEqual(r.result(), "test")
 
     def test_bad_task(self):
-        with self.assertRaises(ClusterException):
-
-            @task(cluster_id="bad_ID")
+        _id = "bad_ID"
+        with self.assertRaises(ClusterException) as ctx:
+            @task(cluster_id=_id)
             def bad_function():
                 return "test"
 
             bad_function()
+        self.assertEqual('No cluster "{}" set!'.format(_id),
+                         ctx.exception.message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-dask>=1.2.2
-distributed>=1.28
+dask>=1.2.2,<2.0.0
+distributed>=1.28,<2.0.0
 dask_jobqueue>=0.5.0
 typing
 pytest-cov


### PR DESCRIPTION
More user-friendly behavior of @on_cluster() and @task()
decorators. This change allows user to pass either
only cluster or cluster_id. It also checks for usage
of LocalCluster which does not have name attribute
that can be used as cluster_id in many places.