### PR TITLE
Exclude extra OpenMPI arguments if MPI is on mpich

### DIFF
--- a/jobqueue_features/tests/test_mpi_wrapper.py
+++ b/jobqueue_features/tests/test_mpi_wrapper.py
@@ -34,7 +34,7 @@ class TestMPIWrap(TestCase):
         if not self.is_mpich():
             self.launcher_args = "--allow-run-as-root --oversubscribe"
         else:
-            self.launcher_args = ''
+            self.launcher_args = ""
         self.script_path = os.path.abspath(
             os.path.join(os.path.dirname(__file__), "resources", "helloworld.py")
         )
@@ -73,9 +73,11 @@ class TestMPIWrap(TestCase):
         self.string_task = string_task
 
     def is_mpich(self):
-        cmd = 'mpicc -v'
-        proc = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if b'mpich' in proc.stdout.read().lower():
+        cmd = "mpicc -v"
+        proc = subprocess.Popen(
+            shlex.split(cmd), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        if b"mpich" in proc.stdout.read().lower():
             return True
         return False
 
@@ -104,13 +106,13 @@ class TestMPIWrap(TestCase):
             result = self.test_function(self.script_path, return_wrapped_command=True)
             _cmd = (
                 self.launcher,
-                '-np',
+                "-np",
                 self.number_of_processes,
                 self.launcher_args,
                 self.executable,
                 self.script_path,
             )
-            expected_result = ' '.join(filter(len, map(str, _cmd)))
+            expected_result = " ".join(filter(len, map(str, _cmd)))
             self.assertEqual(result, expected_result)
         else:
             pass


### PR DESCRIPTION
Local tests are not passing for mpich MPI implementation. This PR prevents from passing extra OpenMPI-specific arguments.