### PR TITLE
Dask jobqueue upgrade

### DIFF
--- a/jobqueue_features/clusters.py
+++ b/jobqueue_features/clusters.py
@@ -4,6 +4,7 @@ from dask import config
 from dask_jobqueue import SLURMCluster, JobQueueCluster
 from dask.distributed import Client, LocalCluster
 from dask_jobqueue.slurm import SLURMJob
+from distributed.utils import ignoring
 from typing import TypeVar, Dict, List, Any  # noqa
 
 from .cli.mpi_dask_worker import MPI_DASK_WRAPPER_MODULE
@@ -554,6 +555,10 @@ class CustomSLURMCluster(CustomClusterMixin, SLURMCluster):
                 logger.debug(warning)
             logger.debug("\n")
         self._add_to_cluster_controller()
+
+    def __del__(self):
+        with ignoring(AttributeError):
+            super().__del__()
 
     def _validate_name(self, name):
         from .clusters_controller import clusters_controller_singleton

--- a/jobqueue_features/clusters_controller.py
+++ b/jobqueue_features/clusters_controller.py
@@ -78,7 +78,7 @@ class ClusterController(object):
     def _close_cluster(self, id_):
         # type: (str) -> None
         cluster = self._clusters.pop(id_, None)
-        if cluster and type(cluster) is not LocalCluster:
+        if cluster and cluster.status != "closed":
             cluster.close()
 
     def _close_clusters(self):

--- a/jobqueue_features/mpi_wrapper.py
+++ b/jobqueue_features/mpi_wrapper.py
@@ -3,7 +3,7 @@ import os
 import shlex
 import subprocess
 import sys
-from typing import Dict  # noqa
+from typing import Dict, Union  # noqa
 
 
 SRUN = "srun"
@@ -20,7 +20,7 @@ __TASK_MPI_COMM = None
 def get_task_mpi_comm():
     """
     This function gets the MPI communicator for the tasks.
-    
+
     :return: MPI Communicator
     """
 
@@ -89,19 +89,18 @@ def which(filename):
 
 
 def mpi_wrap(
-    executable=None,
-    pre_launcher_opts="",
-    mpi_launcher=None,
-    launcher_args="",
-    mpi_tasks=None,
-    nodes=None,
-    cpus_per_task=None,
-    ntasks_per_node=None,
-    exec_args="",
-    return_wrapped_command=False,
+    executable: str = None,
+    pre_launcher_opts: str = "",
+    mpi_launcher: str = None,
+    launcher_args: str = "",
+    mpi_tasks: str = None,
+    nodes: int = None,
+    cpus_per_task: int = None,
+    ntasks_per_node: int = None,
+    exec_args: str = "",
+    return_wrapped_command: bool = False,
     **kwargs
-):
-    # type: (str, str, str, str, str, ...) -> Dict[str, str]
+) -> Union[str, Dict[str, str]]:
     def get_default_mpi_params(
         mpi_launcher, mpi_tasks, nodes, cpus_per_task, ntasks_per_node
     ):

--- a/jobqueue_features/tests/test_cluster.py
+++ b/jobqueue_features/tests/test_cluster.py
@@ -59,10 +59,10 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH --cpus-per-task=1", cluster.job_header)
         self.assertIn("#SBATCH --ntasks-per-node=64", cluster.job_header)
         self.assertIn("#SBATCH -n 64", cluster.job_script())
-        self.assertIn(MPI_DASK_WRAPPER_MODULE, cluster._command_template)
-        self.assertEqual(cluster.worker_cores, 1)
-        self.assertEqual(cluster.worker_processes, 1)
-        self.assertEqual(cluster.worker_process_threads, 1)
+        self.assertIn(MPI_DASK_WRAPPER_MODULE, cluster._dummy_job._command_template)
+        self.assertEqual(cluster._dummy_job.worker_cores, 1)
+        self.assertEqual(cluster._dummy_job.worker_processes, 1)
+        self.assertEqual(cluster._dummy_job.worker_process_threads, 1)
         self.assertIsInstance(cluster.client, Client)
         controller.delete_cluster(cluster.name)
         with self.assertRaises(ValueError):
@@ -76,7 +76,7 @@ class TestClusters(TestCase):
         kwargs = self.kwargs
         kwargs.update({"fork_mpi": True})
         cluster = get_cluster(queue_type="knl", mpi_mode=True, cores=64, **kwargs)
-        self.assertNotIn(MPI_DASK_WRAPPER_MODULE, cluster._command_template)
+        self.assertNotIn(MPI_DASK_WRAPPER_MODULE, cluster._dummy_job._command_template)
         controller.delete_cluster(cluster.name)
 
     def test_mpi_multi_node_job_cluster(self):
@@ -85,9 +85,9 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH --cpus-per-task=1", cluster.job_header)
         self.assertIn("#SBATCH --ntasks-per-node=64", cluster.job_header)
         self.assertIn("#SBATCH -n 130", cluster.job_script())
-        self.assertEqual(cluster.worker_cores, 1)
-        self.assertEqual(cluster.worker_processes, 1)
-        self.assertEqual(cluster.worker_process_threads, 1)
+        self.assertEqual(cluster._dummy_job.worker_cores, 1)
+        self.assertEqual(cluster._dummy_job.worker_processes, 1)
+        self.assertEqual(cluster._dummy_job.worker_process_threads, 1)
         with self.assertRaises(ValueError):
             get_cluster(queue_type="knl", mpi_mode=True, **self.kwargs)
         with self.assertRaises(ValueError):
@@ -117,9 +117,9 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH --ntasks-per-node=4", cluster.job_header)
         self.assertIn("#SBATCH --nodes=2", cluster.job_header)
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
-        self.assertEqual(cluster.worker_cores, 1)
-        self.assertEqual(cluster.worker_processes, 1)
-        self.assertEqual(cluster.worker_process_threads, 1)
+        self.assertEqual(cluster._dummy_job.worker_cores, 1)
+        self.assertEqual(cluster._dummy_job.worker_processes, 1)
+        self.assertEqual(cluster._dummy_job.worker_process_threads, 1)
         self.assertIn("#SBATCH -n 8", cluster.job_script())
         self.assertIn(
             "export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}", cluster.job_script()
@@ -183,9 +183,9 @@ class TestClusters(TestCase):
         self.assertIn("#SBATCH --ntasks-per-node=12", cluster.job_header)
         self.assertIn("#SBATCH --nodes=2", cluster.job_header)
         self.assertIn("#SBATCH --gres=gpu:4", cluster.job_header)
-        self.assertEqual(cluster.worker_cores, 1)
-        self.assertEqual(cluster.worker_processes, 1)
-        self.assertEqual(cluster.worker_process_threads, 1)
+        self.assertEqual(cluster._dummy_job.worker_cores, 1)
+        self.assertEqual(cluster._dummy_job.worker_processes, 1)
+        self.assertEqual(cluster._dummy_job.worker_process_threads, 1)
         self.assertIn("#SBATCH -n 24", cluster.job_script())
         self.assertIn(
             "export OMP_NUM_THREADS=${SLURM_CPUS_PER_TASK}", cluster.job_script()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-dask>=1.2.2,<2.0.0
-distributed>=1.28,<2.0.0
-dask_jobqueue==0.5.0
+dask_jobqueue==0.7
 msgpack==0.6.2
 typing
 pytest-cov


### PR DESCRIPTION
Update code for `dask_jobqueue==0.7`. 
Mainly adapting attributes manipulation in `Job` objects which preciously were in `Cluster`.