### PR TITLE
Don't allow None values to be retained for attributes when…

### DIFF
--- a/jobqueue_features/decorators.py
+++ b/jobqueue_features/decorators.py
@@ -155,7 +155,7 @@ class task(object):
         # type: (ClusterType, Client, Callable, List[...], Dict[...]) -> Future
         # For normal tasks, we maintain the Dask default that functions are pure (by
         # default)
-        kwarg_pure = getattr(kwargs, "pure", True)
+        kwarg_pure = kwargs.get("pure", None)
         cluster_pure = getattr(cluster, "pure", kwarg_pure)
         if cluster_pure is None and kwarg_pure is not None:
             pure = kwarg_pure

--- a/jobqueue_features/decorators.py
+++ b/jobqueue_features/decorators.py
@@ -155,7 +155,13 @@ class task(object):
         # type: (ClusterType, Client, Callable, List[...], Dict[...]) -> Future
         # For normal tasks, we maintain the Dask default that functions are pure (by
         # default)
-        kwargs.update({"pure": getattr(cluster, "pure", getattr(kwargs, "pure", True))})
+        kwarg_pure = getattr(kwargs, "pure", True)
+        cluster_pure = getattr(cluster, "pure", kwarg_pure)
+        if cluster_pure is None and kwarg_pure is not None:
+            pure = kwarg_pure
+        else:
+            pure = cluster_pure
+        kwargs.update({"pure": pure})
         return client.submit(f, *args, **kwargs)
 
 

--- a/jobqueue_features/decorators.py
+++ b/jobqueue_features/decorators.py
@@ -168,7 +168,10 @@ class mpi_task(task):
 
     def _get_cluster_attribute(self, cluster, attribute, default, **kwargs):
         dict_value = kwargs.pop(attribute, default)
-        return getattr(cluster, attribute, dict_value), kwargs
+        return_value = getattr(cluster, attribute, dict_value)
+        if return_value is None and dict_value is not None:
+            return_value = dict_value
+        return return_value, kwargs
 
     def _submit(self, cluster, client, f, *args, **kwargs):
         # For MPI tasks, let's assume functions are not pure (by default)

--- a/jobqueue_features/decorators.py
+++ b/jobqueue_features/decorators.py
@@ -161,7 +161,8 @@ class task(object):
             pure = kwarg_pure
         else:
             pure = cluster_pure
-        kwargs.update({"pure": pure})
+        if pure is not kwarg_pure:
+            kwargs.update({"pure": pure})
         return client.submit(f, *args, **kwargs)
 
 


### PR DESCRIPTION
… a better option exists
Fixes #31 

The cluster object has acquired the attribute `pure=None` upstream (I believe), since we need to toggle this setting we need to include logic to control this attribute.