### PR TITLE
Update setup.py install_requires to match requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,10 @@ setup(
         "dask>=0.18.1",
         "distributed>=1.22.0",
         "dask_jobqueue>=0.4.1",
+        "mpi4py",
         "typing",
         "pytest-cov",
+        "pytest-ordering",
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
Adds missing requirements to setup.py. (My standard install process of `pip install -e .` then running tests was failing without this.)

It also might be worth separating testing requirements as an `extras_require` in the `setup.py`.