### PR TITLE
distributed.utils.ignoring => contextlib.suppress

### DIFF
--- a/jobqueue_features/clusters.py
+++ b/jobqueue_features/clusters.py
@@ -1,12 +1,12 @@
 from __future__ import division
 
 import re
+from contextlib import suppress
 
 from dask import config
 from dask_jobqueue import SLURMCluster, JobQueueCluster
 from dask.distributed import Client, LocalCluster
 from dask_jobqueue.slurm import SLURMJob
-from distributed.utils import ignoring
 from typing import TypeVar, Dict, List, Any  # noqa
 
 from .cli.mpi_dask_worker import MPI_DASK_WRAPPER_MODULE
@@ -611,7 +611,7 @@ class CustomSLURMCluster(CustomClusterMixin, SLURMCluster):
         self._add_to_cluster_controller()
 
     def __del__(self):
-        with ignoring(AttributeError):
+        with suppress(AttributeError):
             super().__del__()
 
     def _validate_name(self, name):


### PR DESCRIPTION
Latest `distributed` release (2.17.0) removes `utils.ignoring` in favor of using the standard library `contextlib.suppress` (`ignoring` was probably leftover from Py2 days). https://github.com/dask/distributed/pull/3819
