### PR TITLE
Use useful names for dask tasks

### DIFF
--- a/jobqueue_features/decorators.py
+++ b/jobqueue_features/decorators.py
@@ -217,6 +217,9 @@ class mpi_task(task):
                 cluster, "ntasks_per_node", None, **kwargs
             )
 
+            executable = kwargs.get("executable", None)
+            if executable:
+                f.__name__ = "fmpi/" + executable
             return super(mpi_task, self)._submit(
                 cluster,
                 client,
@@ -234,6 +237,7 @@ class mpi_task(task):
             # If we are not forking we need to serialize the task and arguments
             serialized_object = serialize_function_and_args(f, *args, **kwargs)
 
+            mpi_deserialize_and_execute.__name__ = "mpi/" + f.__name__
             # Then we submit our deserializing/executing function as the task
             return super(mpi_task, self)._submit(
                 cluster,


### PR DESCRIPTION
This gives tasks submitted to Dask useful names in the graphs of the Dask jupyterlab plugin