### PR TITLE
Add base starting tutorial workspace

### DIFF
--- a/tutorial/docker_config/slurm/workspace.json
+++ b/tutorial/docker_config/slurm/workspace.json
@@ -1,0 +1,129 @@
+{
+  "data": {
+    "layout-restorer:data": {
+      "main": {
+        "dock": {
+          "type": "split-area",
+          "orientation": "horizontal",
+          "sizes": [
+            0.5,
+            0.5
+          ],
+          "children": [
+            {
+              "type": "tab-area",
+              "currentIndex": 0,
+              "widgets": [
+                "notebook:local_cluster.ipynb"
+              ]
+            },
+            {
+              "type": "split-area",
+              "orientation": "vertical",
+              "sizes": [
+                0.25,
+                0.25,
+                0.25,
+                0.25
+              ],
+              "children": [
+                {
+                  "type": "tab-area",
+                  "currentIndex": 0,
+                  "widgets": [
+                    "dask-dashboard-launcher:/individual-progress"
+                  ]
+                },
+                {
+                  "type": "tab-area",
+                  "currentIndex": 0,
+                  "widgets": [
+                    "dask-dashboard-launcher:/individual-profile"
+                  ]
+                },
+                {
+                  "type": "tab-area",
+                  "currentIndex": 0,
+                  "widgets": [
+                    "dask-dashboard-launcher:/individual-task-stream"
+                  ]
+                },
+                {
+                  "type": "tab-area",
+                  "currentIndex": 0,
+                  "widgets": [
+                    "dask-dashboard-launcher:/individual-workers"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "left": {
+        "collapsed": false,
+        "current": "filebrowser",
+        "widgets": [
+          "filebrowser",
+          "running-sessions",
+          "dask-dashboard-launcher",
+          "@jupyterlab/toc:plugin",
+          "extensionmanager.main-view"
+        ]
+      },
+      "right": {
+        "collapsed": true,
+        "widgets": [
+          "jp-property-inspector"
+        ]
+      }
+    },
+    "file-browser-filebrowser:cwd": {
+      "path": ""
+    },
+    "notebook:local_cluster.ipynb": {
+      "data": {
+        "path": "local_cluster.ipynb",
+        "factory": "Notebook"
+      }
+    },
+    "dask-dashboard-launcher:/individual-task-stream": {
+      "data": {
+        "route": "/individual-task-stream",
+        "label": "Task Stream",
+        "key": "Task Stream"
+      }
+    },
+    "dask-dashboard-launcher:/individual-progress": {
+      "data": {
+        "route": "/individual-progress",
+        "label": "Progress",
+        "key": "Progress"
+      }
+    },
+    "dask-dashboard-launcher:/individual-workers": {
+      "data": {
+        "route": "/individual-workers",
+        "label": "Workers",
+        "key": "Workers"
+      }
+    },
+    "dask-dashboard-launcher:/individual-profile": {
+      "data": {
+        "route": "/individual-profile",
+        "label": "Profile",
+        "key": "Profile"
+      }
+    },
+    "workspace-ui:lastSave": "/new-workspace.jupyterlab-workspace",
+    "dask-dashboard-launcher": {
+      "url": "",
+      "cluster": ""
+    }
+  },
+  "metadata": {
+    "id": "/lab",
+    "last_modified": "2021-01-20T13:45:41.000778+00:00",
+    "created": "2021-01-20T13:45:41.000778+00:00"
+  }
+}

--- a/tutorial/jupyter.sh
+++ b/tutorial/jupyter.sh
@@ -10,7 +10,7 @@ function start_slurm() {
     docker exec slurmctld /bin/bash -c "conda install -c conda-forge jupyterlab"
     docker exec slurmctld /bin/bash -c "conda install -c conda-forge distributed"
     docker exec slurmctld /bin/bash -c "conda install -c conda-forge nodejs"
-    docker exec slurmctld /bin/bash -c "pip install dask_labextension"
+    docker exec slurmctld /bin/bash -c "pip install dask-labextension"
     docker exec slurmctld /bin/bash -c "cd /jobqueue_features; pip install -r requirements.txt; pip install --no-deps -e ."
     docker exec c1 /bin/bash -c "cd /jobqueue_features; pip install -r requirements.txt; pip install --no-deps -e ."
     docker exec c2 /bin/bash -c "cd /jobqueue_features; pip install -r requirements.txt; pip install --no-deps -e ."
@@ -22,13 +22,14 @@ function start_slurm() {
     cd "$JUPYTER_CONTAINERS_DIR/docker_config/slurm"
       docker cp labextension.yaml slurmctld:/home/slurmuser/.config/dask/labextension.yaml
     cd -
-    docker exec -u slurmuser slurmctld /bin/bash -c "chmod u=rw,go=r /home/slurmuser/.config/dask/labextension.yaml"
+    docker exec slurmctld /bin/bash -c "chown -R slurmuser /home/slurmuser/"
+    docker exec -u slurmuser slurmctld /bin/bash -c "jupyter lab workspace import /jobqueue_features/tutorial/docker_config/slurm/workspace.json"
     docker exec -u slurmuser slurmctld /bin/bash -c "cd /jobqueue_features/tutorial/docker_config/slurm/tutorial_tasks; jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.notebook_dir='/jobqueue_features/tutorial/docker_config/slurm/tutorial_tasks'&"
 
     echo
     echo -e "\e[32mSLURM properly configured\e[0m"
     echo
-    echo -e "\tOpen your browser at http://localhost:8888/lab"
+    echo -e "\tOpen your browser at http://localhost:8888/lab/workspaces/lab"
     echo
 }
 


### PR DESCRIPTION
Those only a proposal of workspace look for out jupyterlab.
For test before merge change `function start_slurm()` in `tutorial/jupyter.sh':
```
function start_slurm() {
    cd "$JUPYTER_CONTAINERS_DIR/docker_config/slurm"
      ./start-slurm.sh
    cd -

    docker exec slurmctld /bin/bash -c "conda install -c conda-forge jupyterlab"
    docker exec slurmctld /bin/bash -c "conda install -c conda-forge distributed"
    docker exec slurmctld /bin/bash -c "conda install -c conda-forge nodejs"
    docker exec slurmctld /bin/bash -c "pip install dask-labextension"
    docker exec slurmctld /bin/bash -c "cd /jobqueue_features; pip install -r requirements.txt; pip install --no-deps -e ."
    docker exec c1 /bin/bash -c "cd /jobqueue_features; pip install -r requirements.txt; pip install --no-deps -e ."
    docker exec c2 /bin/bash -c "cd /jobqueue_features; pip install -r requirements.txt; pip install --no-deps -e ."
    docker exec slurmctld /bin/bash -c "adduser slurmuser; chown -R slurmuser /jobqueue_features;"
    docker exec c1 /bin/bash -c "adduser slurmuser; chown -R slurmuser /jobqueue_features;"
    docker exec c2 /bin/bash -c "adduser slurmuser; chown -R slurmuser /jobqueue_features;"
    docker exec slurmctld /bin/bash -c "yes|sacctmgr create account slurmuser; yes | sacctmgr create user name=slurmuser Account=slurmuser"
    docker exec slurmctld /bin/bash -c "mkdir -p /home/slurmuser/.config/dask/"
    cd "$JUPYTER_CONTAINERS_DIR/docker_config/slurm"
      docker cp labextension.yaml slurmctld:/home/slurmuser/.config/dask/labextension.yaml
      docker cp workspace.json slurmctld:/jobqueue_features/tutorial/docker_config/slurm/workspace.json
    cd -
    docker exec slurmctld /bin/bash -c "chown -R slurmuser /home/slurmuser/"
    docker exec -u slurmuser slurmctld /bin/bash -c "jupyter lab workspace import /jobqueue_features/tutorial/docker_config/slurm/workspace.json"
    docker exec -u slurmuser slurmctld /bin/bash -c "cd /jobqueue_features/tutorial/docker_config/slurm/tutorial_tasks; jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.notebook_dir='/jobqueue_features/tutorial/docker_config/slurm/tutorial_tasks'&"

    echo
    echo -e "\e[32mSLURM properly configured\e[0m"
    echo
    echo -e "\tOpen your browser at http://localhost:8888/lab/workspaces/lab"
    echo
}
```