### PR TITLE
Update README tutorial instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ that defines them. This requires you to first clone the repository:
 git clone https://github.com/E-CAM/jobqueue_features.git
 
 # Enter the directory
-cd jobqueue_features
+cd jobqueue_features/tutorial
 
 # Configure our commands to start/stop/clean our containers
-source tutorial/jupyter.sh
+source jupyter.sh
 ```
 
 The bash functions hide away the details of what is done to start, stop and clean up


### PR DESCRIPTION
Looks like you need to `source` from within the `tutorial` directory.

The actual offending line is here:

https://github.com/E-CAM/jobqueue_features/blob/3b705475ca3faddca43e337d4c2b5ce14cd8016a/tutorial/jupyter.sh#L3

Explanation:

```bash
#!/bin/bash
# file: tutorial/dirname_bash_source0.sh
echo $(dirname "${BASH_SOURCE[0]}")
```

```bash
$ source tutorial/dirname_bash_source0.sh
.
$ bash tutorial/dirname_bash_source0.sh
tutorial
```

(If it was working for you, then this could be a zsh thing.)