### PR TITLE
[WIP] start_jobqueue_tutorial command (Dask-Jobqueue's tutorial)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
         run: |
           source tutorial/jupyter.sh
           start_${{ matrix.jobqueue }}
+          launch_tutorial_${{ matrix.jobqueue }}
 
       - name: Test
         shell: bash -l {0}

--- a/tutorial/jupyter.sh
+++ b/tutorial/jupyter.sh
@@ -26,8 +26,13 @@ function start_slurm() {
     echo
 }
 
+
 function start_tutorial() {
     start_slurm
+    launch_tutorial_slurm
+}
+
+function launch_tutorial_slurm() {
     # Clone the tutorials, import the workspace and start the JupyterLab
     docker exec -u slurmuser slurmctld /bin/bash -c "cd /data; git clone https://github.com/E-CAM/jobqueue_features_workshop_materials.git"
     docker exec -u slurmuser slurmctld /bin/bash -c "jupyter lab workspace import /data/jobqueue_features_workshop_materials/workspace.json"

--- a/tutorial/jupyter.sh
+++ b/tutorial/jupyter.sh
@@ -21,14 +21,26 @@ function start_slurm() {
     cd "$JUPYTER_CONTAINERS_DIR/docker_config/slurm"
       docker cp labextension.yaml slurmctld:/home/slurmuser/.config/dask/labextension.yaml
     cd -
+    echo
+    echo -e "\e[32mSLURM properly configured\e[0m"
+    echo
+}
+
+function start_tutorial() {
+    start_slurm
     # Clone the tutorials, import the workspace and start the JupyterLab
     docker exec -u slurmuser slurmctld /bin/bash -c "cd /data; git clone https://github.com/E-CAM/jobqueue_features_workshop_materials.git"
     docker exec -u slurmuser slurmctld /bin/bash -c "jupyter lab workspace import /data/jobqueue_features_workshop_materials/workspace.json"
     docker exec -u slurmuser slurmctld /bin/bash -c "cd /data/jobqueue_features_workshop_materials; jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.notebook_dir='/data/jobqueue_features_workshop_materials'&"
+    echo -e "\tOpen your browser at http://localhost:8888/lab/workspaces/lab"
+    echo
+}
 
-    echo
-    echo -e "\e[32mSLURM properly configured\e[0m"
-    echo
+function start_jobqueue_tutorial() {
+    start_slurm
+    # Clone jobqueue tutorial, import workspace
+    docker exec -u slurmuser slurmctld /bin/bash -c "cd /data; git clone https://github.com/ExaESM-WP4/workshop-Dask-Jobqueue-cecam-2021-02.git"
+    docker exec -u slurmuser slurmctld /bin/bash -c "cd /data/workshop-Dask-Jobqueue-cecam-2021-02; jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root --NotebookApp.token='' --NotebookApp.password='' --NotebookApp.notebook_dir='/data/workshop-Dask-Jobqueue-cecam-2021-02'&"
     echo -e "\tOpen your browser at http://localhost:8888/lab/workspaces/lab"
     echo
 }


### PR DESCRIPTION
This slightly changes the commands in `jupyter.sh`. The goal here is to have an easy setup for the Dask-Jobqueue tutorial as well. Might revert these back after the workshop.

New setup:

* `start_slurm`: only installs stuff for slurm and jupyter
* `start_tutorial`: calls `start_slurm`, clones jobqueue-features tutorial; launches it in Jupyter Lab
* `start_jobqueue_tutorial`: calls `start_slurm`, clones dask-jobqueue tutorial; launches it in Jupyter Lab

The goal is to have a single command to be used for each tutorial session.

WIP until I do a run-through of much of the jobqueue tutorial.