### PR TITLE
Add function to start up dask-jobqueue tutorial

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
         run: |
           source tutorial/jupyter.sh
           start_${{ matrix.jobqueue }}
+          launch_tutorial_${{ matrix.jobqueue }}
 
       - name: Test
         shell: bash -l {0}

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ defined (e.g., `type start_slurm`).
 There are three bash functions. The first of which sets the environment up:
 ```
 # Start and configure the cluster
-start_slurm
+start_tutorial
 ```
 This step includes cloning the tutorial (which can be found at
 https://github.com/E-CAM/jobqueue_features_workshop_materials) *inside* the cluster.


### PR DESCRIPTION
New version of #96.

* `start_tutorial`: start jobqueue-features tutorial
* `start_jobqueue_tutorial`: start dask-jobqueue tutorial

Also adds a git pull after cloning. Necessary to update people who did the jobqueue tutorial yesterday. (Obviously won't solve if people made conflicting changes, though).