### PR TITLE
Make sure we 'none' CI uses specified Python

### DIFF
--- a/ci/none.sh
+++ b/ci/none.sh
@@ -3,6 +3,8 @@
 function jobqueue_before_install {
   # Install miniconda
   ./ci/conda_setup.sh
+  # Default to Python 3.8
+  if [ -z ${PYTHON_VERSION+x} ]; then export PYTHON_VERSION=3.8; else echo "Python version is set to '$PYTHON_VERSION'"; fi
   PATH="$HOME/miniconda/bin:$PATH" conda install --yes -c conda-forge python=$PYTHON_VERSION flake8 black pytest pytest-asyncio codespell openmpi
   # also install OpenMPI and mpi4py
   PATH="$HOME/miniconda/bin:$PATH" conda install --yes -c conda-forge python=$PYTHON_VERSION openmpi-mpicc mpi4py

--- a/ci/none.sh
+++ b/ci/none.sh
@@ -3,15 +3,15 @@
 function jobqueue_before_install {
   # Install miniconda
   ./ci/conda_setup.sh
-  PATH="$HOME/miniconda/bin:$PATH" conda install --yes -c conda-forge python=3.8 flake8 black pytest pytest-asyncio codespell openmpi
+  PATH="$HOME/miniconda/bin:$PATH" conda install --yes -c conda-forge python=$PYTHON_VERSION flake8 black pytest pytest-asyncio codespell openmpi
   # also install OpenMPI and mpi4py
-  PATH="$HOME/miniconda/bin:$PATH" conda install --yes -c conda-forge python=3.8 openmpi mpi4py
+  PATH="$HOME/miniconda/bin:$PATH" conda install --yes -c conda-forge python=$PYTHON_VERSION openmpi-mpicc mpi4py
 }
 
 function jobqueue_install {
   which python
   # Make sure requirements are met
-  PATH="$HOME/miniconda/bin:$PATH" pip install -r requirements.txt
+  PATH="$HOME/miniconda/bin:$PATH" pip install --upgrade -r requirements.txt
   PATH="$HOME/miniconda/bin:$PATH" pip install --no-deps -e .
 }
 


### PR DESCRIPTION
We were not picking up the specified Python version for the `none` CI case (but it doesn't really matter since all options are covered under `slurm` anyway)