### PR TITLE
Try to fix intermittent CI failure

### DIFF
--- a/jobqueue_features/clusters_controller.py
+++ b/jobqueue_features/clusters_controller.py
@@ -79,6 +79,7 @@ class ClusterController(object):
         if cluster and cluster.status != "closed":
             with suppress(AttributeError):
                 cluster._adaptive.stop()
+            cluster.scale(0)
             cluster.close(timeout=10)
 
     def _close_clusters(self) -> None:


### PR DESCRIPTION
I have seen failures in the scheduled CI ([see this for an example](https://github.com/E-CAM/jobqueue_features/runs/3647161794?check_suite_focus=true#step:9:169)) that seems to occur pretty regularly but is not linked to any particular iteration in the CI (though seems to occur more frequently with PBS).

Since I'm shooting in the dark, I just added something that shouldn't do any harm but might solve the problem. CI is passing so I'm going to merge and wait and see if that resolves the issue going forward. 